### PR TITLE
fix: Use the 'types' entry in the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "Apache-2.0",
   "author": "Simen A. W. Olsen",
   "type": "module",
+  "types": "./dist/src/plugin.d.ts",
   "exports": "./dist/src/plugin.js",
   "files": [
     "./dist/src"


### PR DESCRIPTION
I had the following issue with v2.1.0:
`Cannot find module 'nestjs-envalid' or its corresponding type declarations.`

I made these changes directly on the module in my `node_modules` and it solved the issue.

According to the [official Typescript documentation](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package), the `types` field is required to properly 'expose' the types to your package users.